### PR TITLE
feat(ai): add tool-calling agent (list_chats, get_user_info, read_chat_messages)

### DIFF
--- a/Telegram/SourceFiles/ai/openai_client.cpp
+++ b/Telegram/SourceFiles/ai/openai_client.cpp
@@ -13,10 +13,15 @@ https://github.com/fedorn/telebrain/blob/dev/LEGAL
 #include "core/core_settings.h"
 #include "data/data_forum_topic.h"
 #include "data/data_histories.h"
+#include "data/data_peer.h"
+#include "data/data_peer_id.h"
 #include "data/data_replies_list.h"
 #include "data/data_session.h"
 #include "data/data_thread.h"
 #include "data/data_user.h"
+#include "dialogs/dialogs_indexed_list.h"
+#include "dialogs/dialogs_key.h"
+#include "dialogs/dialogs_row.h"
 #include "history/history.h"
 #include "history/history_item.h"
 #include "base/unixtime.h"
@@ -44,72 +49,26 @@ void OpenAIClient::setSessionController(not_null<Window::SessionController*> con
 	_sessionController = controller.get();
 }
 
-void OpenAIClient::sendChatCompletion(
-		const std::vector<MessageData> &messages,
-		std::function<void(const QString &)> onSuccess,
-		std::function<void(const QString &)> onError) {
-	
-	if (_isWaitingForResponse) {
-		onError("Already waiting for a response. Please wait for the current request to complete.");
+void OpenAIClient::ensureContextLoaded(std::function<void()> done) {
+	if (!_sessionController) {
+		done();
 		return;
 	}
-	_onSuccess = std::move(onSuccess);
-	_onError = std::move(onError);
-	_isWaitingForResponse = true;
-
-	auto messagesCopy = messages;
-	getChatContext([this, messagesCopy = std::move(messagesCopy)](QString chatContext) {
-		QString baseUrl = Core::App().settings().aiChatBaseUrl();
-		if (baseUrl.isEmpty()) {
-			baseUrl = "https://openrouter.ai/api/v1";
-		}
-		QString openaiApiKey = Core::App().settings().aiChatApiKey();
-
-		QNetworkRequest request(QUrl(baseUrl + "/chat/completions"));
-		request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-		request.setRawHeader("HTTP-Referer", QByteArray("https://github.com/fedorn/telebrain"));
-		request.setRawHeader("X-Title", QByteArray("Telebrain"));
-		if (!openaiApiKey.isEmpty()) {
-			request.setRawHeader("Authorization", QString("Bearer %1").arg(openaiApiKey).toUtf8());
-		}
-		request.setTransferTimeout(60000);
-
-		QJsonArray messagesArray;
-		messagesArray.append(QJsonObject{
-			{"role", "system"},
-			{"content", prepareSystemMessage(chatContext)}
-		});
-
-		const int maxHistory = 100;
-		const int startIndex = std::max(0, static_cast<int>(messagesCopy.size()) - maxHistory);
-		for (int i = startIndex; i < static_cast<int>(messagesCopy.size()); ++i) {
-			const auto &msg = messagesCopy[i];
-			if (msg.text == kThinkingMessage || msg.text == kWelcomeMessage) {
-				continue;
-			}
-			messagesArray.append(QJsonObject{
-				{"role", msg.isFromUser ? "user" : "assistant"},
-				{"content", msg.text}
-			});
-		}
-
-		QJsonObject requestBody = createRequestBody(messagesArray);
-		QJsonDocument doc(requestBody);
-		QByteArray data = doc.toJson();
-
-		QNetworkReply *reply = _networkManager->post(request, data);
-
-		connect(reply, &QNetworkReply::finished, this, [this, reply]() {
-			handleResponse(reply);
-			reply->deleteLater();
-		});
-
-		connect(reply, &QNetworkReply::errorOccurred,
-			this, [this, reply](QNetworkReply::NetworkError error) {
-				handleNetworkError(error, reply->errorString());
-				reply->deleteLater();
-			});
-	});
+	const auto activeChat = _sessionController->activeChatCurrent();
+	const auto history = activeChat.owningHistory();
+	if (!history) {
+		done();
+		return;
+	}
+	const auto topic = activeChat.topic();
+	if (topic) {
+		topic->replies()->requestRecentForContext(kContextMessageCount, std::move(done));
+	} else {
+		history->owner().histories().requestRecentForContext(
+			history,
+			kContextMessageCount,
+			std::move(done));
+	}
 }
 
 bool OpenAIClient::isWaitingForResponse() const {
@@ -117,17 +76,16 @@ bool OpenAIClient::isWaitingForResponse() const {
 }
 
 void OpenAIClient::handleResponse(QNetworkReply *reply) {
-	_isWaitingForResponse = false;
-
 	if (reply->error() != QNetworkReply::NoError) {
+		_isWaitingForResponse = false;
 		return;
 	}
 
 	QByteArray responseData = reply->readAll();
 	QJsonParseError parseError;
 	QJsonDocument jsonResponse = QJsonDocument::fromJson(responseData, &parseError);
-
 	if (parseError.error != QJsonParseError::NoError) {
+		_isWaitingForResponse = false;
 		if (_onError) {
 			_onError(QString("JSON parse error: %1").arg(parseError.errorString()));
 		}
@@ -135,9 +93,8 @@ void OpenAIClient::handleResponse(QNetworkReply *reply) {
 	}
 
 	QJsonObject responseObj = jsonResponse.object();
-	
-	// Check for API errors
 	if (responseObj.contains("error")) {
+		_isWaitingForResponse = false;
 		QJsonObject errorObj = responseObj["error"].toObject();
 		QString errorMessage = errorObj["message"].toString();
 		if (_onError) {
@@ -146,9 +103,9 @@ void OpenAIClient::handleResponse(QNetworkReply *reply) {
 		return;
 	}
 
-	// Extract the response text
 	QJsonArray choices = responseObj["choices"].toArray();
 	if (choices.isEmpty()) {
+		_isWaitingForResponse = false;
 		if (_onError) {
 			_onError("No response from OpenAI API");
 		}
@@ -156,19 +113,36 @@ void OpenAIClient::handleResponse(QNetworkReply *reply) {
 	}
 
 	QJsonObject choice = choices[0].toObject();
+	QString finishReason = choice["finish_reason"].toString();
 	QJsonObject message = choice["message"].toObject();
-	QString aiResponse = message["content"].toString();
+	QJsonValue contentValue = message["content"];
+	QString aiResponse = contentValue.isString() ? contentValue.toString() : QString();
+	QJsonArray toolCalls = message["tool_calls"].toArray();
 
-	if (aiResponse.isEmpty()) {
+	if (!toolCalls.isEmpty()) {
+		QJsonObject assistantMessage;
+		assistantMessage["role"] = "assistant";
+		assistantMessage["content"] = contentValue.isNull() ? QJsonValue(QString()) : contentValue;
+		assistantMessage["tool_calls"] = toolCalls;
+		_lastSentMessages.append(assistantMessage);
+		processToolCalls(toolCalls, [this](const QJsonArray &toolMessages) {
+			for (const auto &m : toolMessages) {
+				_lastSentMessages.append(m);
+			}
+			sendCompletionRequest(_lastSentMessages);
+		});
+		return;
+	}
+
+	_isWaitingForResponse = false;
+	if (aiResponse.isEmpty() && finishReason != "stop") {
 		if (_onError) {
 			_onError("Empty response from OpenAI API");
 		}
 		return;
 	}
-
-	// Call success callback
 	if (_onSuccess) {
-		_onSuccess(aiResponse);
+		_onSuccess(aiResponse.isEmpty() ? QString() : aiResponse);
 	}
 }
 
@@ -180,7 +154,7 @@ void OpenAIClient::handleNetworkError(QNetworkReply::NetworkError error, const Q
 	}
 }
 
-QString OpenAIClient::prepareSystemMessage(const QString &chatContext) const {
+QString OpenAIClient::prepareSystemMessage() const {
 	QString systemMessage = "You are Telebrain — the AI Copilot integrated into Telegram Desktop. Be concise, helpful, and context-aware. Use the conversation context when relevant, ask clarifying questions when information is missing, and avoid fabricating Telegram data you cannot access.\n\nFormatting: use **text** for bold and __text__ for italic. Do not use other markdown; only these two patterns will be rendered.";
 	QString currentDate = QDateTime::currentDateTime().toString("MMMM d, yyyy");
 	systemMessage += QString("\n\nToday's date is: %1").arg(currentDate);
@@ -199,10 +173,6 @@ QString OpenAIClient::prepareSystemMessage(const QString &chatContext) const {
 		userInfo += "- The user is asking you questions and seeking assistance.\n";
 
 		systemMessage += userInfo;
-
-		if (!chatContext.isEmpty()) {
-			systemMessage += chatContext;
-		}
 	}
 
 	return systemMessage;
@@ -259,20 +229,298 @@ void OpenAIClient::getChatContext(std::function<void(QString)> done) {
 	}
 }
 
+QJsonArray OpenAIClient::buildToolsDefinition() const {
+	QJsonArray tools;
+	QJsonObject listChatsParams;
+	listChatsParams["type"] = "object";
+	QJsonObject listChatsProps;
+	listChatsProps["limit"] = QJsonObject{
+		{"type", "integer"},
+		{"description", "Max number of chats to return (default 50)"}
+	};
+	listChatsParams["properties"] = listChatsProps;
+	tools.append(QJsonObject{
+		{"type", "function"},
+		{"function", QJsonObject{
+			{"name", "list_chats"},
+			{"description", "Get the list of the user's chats (dialogs). Returns chat id, name, and type for each chat."},
+			{"parameters", listChatsParams}
+		}}
+	});
+	QJsonObject getUserInfoParams;
+	getUserInfoParams["type"] = "object";
+	getUserInfoParams["properties"] = QJsonObject{
+		{"user_id", QJsonObject{{"type", "integer"}, {"description", "Telegram user id (numeric)"}}},
+		{"username", QJsonObject{{"type", "string"}, {"description", "Username without @ (e.g. telegram)"}}}
+	};
+	tools.append(QJsonObject{
+		{"type", "function"},
+		{"function", QJsonObject{
+			{"name", "get_user_info"},
+			{"description", "Get information about a Telegram user by user id or username."},
+			{"parameters", getUserInfoParams}
+		}}
+	});
+	QJsonObject readMessagesParams;
+	readMessagesParams["type"] = "object";
+	readMessagesParams["required"] = QJsonArray{"chat_id"};
+	readMessagesParams["properties"] = QJsonObject{
+		{"chat_id", QJsonObject{{"type", "integer"}, {"description", "Chat/peer id from list_chats"}}},
+		{"count", QJsonObject{{"type", "integer"}, {"description", "Number of messages to read (1-100, default 20)"}}}
+	};
+	tools.append(QJsonObject{
+		{"type", "function"},
+		{"function", QJsonObject{
+			{"name", "read_chat_messages"},
+			{"description", "Read the last N messages in a chat. Use chat_id from list_chats."},
+			{"parameters", readMessagesParams}
+		}}
+	});
+	return tools;
+}
+
 QJsonObject OpenAIClient::createRequestBody(const QJsonArray &messages) const {
 	QJsonObject requestBody;
-	
-	// Get model from settings, default to stepfun/step-3.5-flash:free if not set
 	QString model = Core::App().settings().aiChatModel();
 	if (model.isEmpty()) {
 		model = "stepfun/step-3.5-flash:free";
 	}
-	
 	requestBody["model"] = model;
 	requestBody["messages"] = messages;
 	requestBody["store"] = true;
-	
+	requestBody["tools"] = buildToolsDefinition();
 	return requestBody;
+}
+
+void OpenAIClient::sendCompletionRequest(QJsonArray messages) {
+	_lastSentMessages = std::move(messages);
+	QString baseUrl = Core::App().settings().aiChatBaseUrl();
+	if (baseUrl.isEmpty()) {
+		baseUrl = "https://openrouter.ai/api/v1";
+	}
+	QString openaiApiKey = Core::App().settings().aiChatApiKey();
+	QNetworkRequest request(QUrl(baseUrl + "/chat/completions"));
+	request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+	if (!openaiApiKey.isEmpty()) {
+		request.setRawHeader("Authorization", QString("Bearer %1").arg(openaiApiKey).toUtf8());
+	}
+	request.setTransferTimeout(60000);
+	QJsonObject requestBody = createRequestBody(_lastSentMessages);
+	QJsonDocument doc(requestBody);
+	QByteArray data = doc.toJson();
+	QNetworkReply *reply = _networkManager->post(request, data);
+	connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+		handleResponse(reply);
+		reply->deleteLater();
+	});
+	connect(reply, &QNetworkReply::errorOccurred,
+		this, [this, reply](QNetworkReply::NetworkError error) {
+			handleNetworkError(error, reply->errorString());
+			reply->deleteLater();
+		});
+}
+
+void OpenAIClient::sendChatCompletion(
+		const std::vector<MessageData> &messages,
+		std::function<void(const QString &)> onSuccess,
+		std::function<void(const QString &)> onError) {
+
+	if (_isWaitingForResponse) {
+		onError("Already waiting for a response. Please wait for the current request to complete.");
+		return;
+	}
+	_onSuccess = std::move(onSuccess);
+	_onError = std::move(onError);
+	_isWaitingForResponse = true;
+
+	QJsonArray messagesArray;
+	messagesArray.append(QJsonObject{
+		{"role", "system"},
+		{"content", prepareSystemMessage()}
+	});
+	const int maxHistory = 100;
+	const int startIndex = std::max(0, static_cast<int>(messages.size()) - maxHistory);
+	for (int i = startIndex; i < static_cast<int>(messages.size()); ++i) {
+		const auto &msg = messages[i];
+		if (msg.text == kThinkingMessage || msg.text == kWelcomeMessage) {
+			continue;
+		}
+		messagesArray.append(QJsonObject{
+			{"role", msg.isFromUser ? "user" : "assistant"},
+			{"content", msg.text}
+		});
+	}
+	sendCompletionRequest(std::move(messagesArray));
+}
+
+QString OpenAIClient::executeToolListChats(const QJsonObject &args) const {
+	if (!_sessionController) {
+		return QStringLiteral("{\"error\": \"No session\"}");
+	}
+	const auto limit = std::min(50, std::max(1, args["limit"].toInt(50)));
+	QJsonArray chats;
+	const auto list = _sessionController->session().data().chatsList()->indexed();
+	int count = 0;
+	for (const auto &row : *list) {
+		if (count >= limit) {
+			break;
+		}
+		const auto history = row->history();
+		if (!history) {
+			continue;
+		}
+		const auto peer = history->peer;
+		QString type = peer->isUser() ? "user" : (peer->isChat() ? "chat" : "channel");
+		QJsonObject obj;
+		obj["chat_id"] = QJsonValue(static_cast<qint64>(peer->id.value));
+		obj["name"] = peer->name();
+		obj["type"] = type;
+		if (const auto user = peer->asUser()) {
+			const auto u = user->username();
+			if (!u.isEmpty()) {
+				obj["username"] = u;
+			}
+		}
+		chats.append(obj);
+		++count;
+	}
+	QJsonObject out;
+	out["chats"] = chats;
+	return QString::fromUtf8(QJsonDocument(out).toJson(QJsonDocument::Compact));
+}
+
+QString OpenAIClient::executeToolGetUserInfo(const QJsonObject &args) const {
+	if (!_sessionController) {
+		return QStringLiteral("{\"error\": \"No session\"}");
+	}
+	auto &data = _sessionController->session().data();
+	UserData *user = nullptr;
+	if (args.contains("user_id")) {
+		const auto id = args["user_id"].toInteger(0);
+		user = data.user(UserId(static_cast<BareId>(id)));
+	}
+	if (!user && args.contains("username")) {
+		auto username = args["username"].toString().trimmed();
+		if (username.startsWith('@')) {
+			username = username.mid(1);
+		}
+		if (!username.isEmpty()) {
+			const auto peer = data.peerByUsername(username);
+			if (peer && peer->isUser()) {
+				user = peer->asUser();
+			}
+		}
+	}
+	if (!user) {
+		return QStringLiteral("{\"error\": \"User not found\"}");
+	}
+	QJsonObject out;
+	out["user_id"] = QJsonValue(static_cast<qint64>(user->id.value));
+	out["name"] = user->name();
+	const auto u = user->username();
+	if (!u.isEmpty()) {
+		out["username"] = u;
+	}
+	return QString::fromUtf8(QJsonDocument(out).toJson(QJsonDocument::Compact));
+}
+
+void OpenAIClient::executeToolReadChatMessages(
+		uint64 chatId,
+		int count,
+		std::function<void(const QString &)> done) {
+	if (!_sessionController) {
+		done(QStringLiteral("{\"error\": \"No session\"}"));
+		return;
+	}
+	count = std::min(100, std::max(1, count));
+	const auto peerId = PeerId(PeerIdHelper(chatId));
+	auto &data = _sessionController->session().data();
+	const auto history = data.history(peerId);
+	history->owner().histories().requestRecentForContext(
+		history,
+		count,
+		[history, count, done]() {
+			const auto items = history->recentMessagesForContext(MsgId(0), count);
+			QJsonArray arr;
+			for (const auto &item : items) {
+				QJsonObject m;
+				m["sender"] = item->displayFrom()->name();
+				m["date"] = QDateTime::fromSecsSinceEpoch(item->date()).toString(Qt::ISODate);
+				m["text"] = item->originalText().text;
+				arr.append(m);
+			}
+			QJsonObject out;
+			out["messages"] = arr;
+			done(QString::fromUtf8(QJsonDocument(out).toJson(QJsonDocument::Compact)));
+		});
+}
+
+void OpenAIClient::processToolCalls(
+		const QJsonArray &toolCalls,
+		std::function<void(const QJsonArray &)> done) {
+	struct State {
+		QJsonArray results;
+		int pending = 0;
+		std::function<void(const QJsonArray &)> done;
+	};
+	const auto state = std::make_shared<State>();
+	for (int i = 0; i < toolCalls.size(); ++i) {
+		state->results.append(QJsonValue());
+	}
+	state->done = std::move(done);
+	for (int i = 0; i < toolCalls.size(); ++i) {
+		const auto tc = toolCalls[i].toObject();
+		const auto id = tc["id"].toString();
+		const auto func = tc["function"].toObject();
+		const auto name = func["name"].toString();
+		QJsonObject args;
+		const auto argsStr = func["arguments"].toString();
+		if (!argsStr.isEmpty()) {
+			QJsonParseError err;
+			const auto doc = QJsonDocument::fromJson(argsStr.toUtf8(), &err);
+			if (err.error == QJsonParseError::NoError && doc.isObject()) {
+				args = doc.object();
+			}
+		}
+		if (name == "list_chats") {
+			state->results[i] = QJsonObject{
+				{"role", "tool"},
+				{"tool_call_id", id},
+				{"content", executeToolListChats(args)}
+			};
+		} else if (name == "get_user_info") {
+			state->results[i] = QJsonObject{
+				{"role", "tool"},
+				{"tool_call_id", id},
+				{"content", executeToolGetUserInfo(args)}
+			};
+		} else if (name == "read_chat_messages") {
+			state->pending++;
+			const auto chatId = static_cast<uint64>(args["chat_id"].toInteger(0));
+			const auto count = args["count"].toInt(20);
+			const auto index = i;
+			executeToolReadChatMessages(chatId, count, [state, index, id](const QString &content) {
+				state->results[index] = QJsonObject{
+					{"role", "tool"},
+					{"tool_call_id", id},
+					{"content", content}
+				};
+				state->pending--;
+				if (state->pending == 0) {
+					state->done(state->results);
+				}
+			});
+		} else {
+			state->results[i] = QJsonObject{
+				{"role", "tool"},
+				{"tool_call_id", id},
+				{"content", QStringLiteral("{\"error\": \"Unknown tool\"}")}
+			};
+		}
+	}
+	if (state->pending == 0) {
+		state->done(state->results);
+	}
 }
 
 } // namespace AI 

--- a/Telegram/SourceFiles/ai/openai_client.h
+++ b/Telegram/SourceFiles/ai/openai_client.h
@@ -48,26 +48,36 @@ public:
 	// Check if currently waiting for a response
 	bool isWaitingForResponse() const;
 
+	void ensureContextLoaded(std::function<void()> done);
+
 private Q_SLOTS:
-	void handleResponse(QNetworkReply *reply);
 	void handleNetworkError(QNetworkReply::NetworkError error, const QString &errorString);
 
 private:
-	QString prepareSystemMessage(const QString &chatContext) const;
+	QString prepareSystemMessage() const;
 	void getChatContext(std::function<void(QString)> done);
-		
-	// Create the request body
 	QJsonObject createRequestBody(const QJsonArray &messages) const;
+	QJsonArray buildToolsDefinition() const;
+
+	void sendCompletionRequest(QJsonArray messages);
+	void handleResponse(QNetworkReply *reply);
+
+	QString executeToolListChats(const QJsonObject &args) const;
+	QString executeToolGetUserInfo(const QJsonObject &args) const;
+	void executeToolReadChatMessages(
+		uint64 chatId,
+		int count,
+		std::function<void(const QString &)> done);
+	void processToolCalls(
+		const QJsonArray &toolCalls,
+		std::function<void(const QJsonArray &)> done);
 
 	std::unique_ptr<QNetworkAccessManager> _networkManager;
 	bool _isWaitingForResponse = false;
-	
-	// Callbacks for the current request
 	std::function<void(const QString &)> _onSuccess;
 	std::function<void(const QString &)> _onError;
-	
-	// Session controller for getting user and chat context
 	Window::SessionController* _sessionController = nullptr;
+	QJsonArray _lastSentMessages;
 };
 
 } // namespace AI 


### PR DESCRIPTION
## Summary

Adds an AI tool-calling agent so the AI can use Telegram data via three tools: list chats, get user info, and read chat messages. The client handles tool calls from the API, runs the right tool, and sends tool results back in a follow-up completion request.

## Changes

- **Tool definitions**: `buildToolsDefinition()` defines `list_chats`, `get_user_info`, and `read_chat_messages` for the chat completion request.
- **Tool execution**:
  - `list_chats`: Returns dialogs (chat id, name, type, optional username) with a configurable limit.
  - `get_user_info`: Resolves user by `user_id` or `username` and returns id, name, and username.
  - `read_chat_messages`: Loads recent messages for a chat via `requestRecentForContext` and returns sender, date, and text.
- **Request flow**: `sendCompletionRequest()` sends the payload; `handleResponse()` detects `tool_calls`, runs `processToolCalls()`, appends tool-result messages to `_lastSentMessages`, and calls `sendCompletionRequest()` again for the next turn.
- **Context loading**: Chat context is no longer fetched inside the completion path. `ensureContextLoaded(done)` is added so callers can preload context (e.g. for the current chat/topic) before starting a completion.
- **System message**: `prepareSystemMessage()` no longer takes or injects chat context; the system prompt is built without it.