### PR TITLE
Telebrain intro screen - Claude Opus 4.6 variant

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -359,6 +359,8 @@ PRIVATE
     boxes/sticker_set_box.h
     boxes/stickers_box.cpp
     boxes/stickers_box.h
+    boxes/telebrain_setup_box.cpp
+    boxes/telebrain_setup_box.h
     boxes/transfer_gift_box.cpp
     boxes/transfer_gift_box.h
     boxes/translate_box.cpp

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -368,6 +368,13 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_intro_about_telebrain" = "Welcome to the Telebrain app.\nIt's smart.";
 "lng_start_msgs" = "Start Messaging";
 
+"lng_telebrain_setup_title" = "Telebrain Setup";
+"lng_telebrain_setup_description" = "To use Telebrain AI features, you need an API key from OpenRouter. Get a free key and paste it below.";
+"lng_telebrain_setup_get_key" = "Get API key from OpenRouter";
+"lng_telebrain_setup_api_key_placeholder" = "Paste your API key here";
+"lng_telebrain_setup_save" = "Save & Continue";
+"lng_telebrain_setup_skip" = "Skip";
+
 "lng_intro_next" = "Next";
 "lng_intro_finish" = "Sign Up";
 "lng_intro_submit" = "Submit";

--- a/Telegram/SourceFiles/boxes/telebrain_setup_box.cpp
+++ b/Telegram/SourceFiles/boxes/telebrain_setup_box.cpp
@@ -1,0 +1,63 @@
+/*
+This file is part of Telebrain, a fork of Telegram Desktop with AI Copilot.
+
+For license and copyright information please follow this link:
+https://github.com/fedorn/telebrain/blob/dev/LEGAL
+*/
+#include "boxes/telebrain_setup_box.h"
+
+#include "core/application.h"
+#include "core/core_settings.h"
+#include "core/file_utilities.h"
+#include "lang/lang_keys.h"
+#include "ui/widgets/buttons.h"
+#include "ui/widgets/fields/input_field.h"
+#include "ui/widgets/labels.h"
+#include "styles/style_layers.h"
+
+void TelebrainSetupBox(not_null<Ui::GenericBox*> box) {
+	box->setTitle(tr::lng_telebrain_setup_title());
+	box->setWidth(st::boxWideWidth);
+
+	const auto padding = st::boxPadding;
+
+	box->addRow(
+		object_ptr<Ui::FlatLabel>(
+			box,
+			tr::lng_telebrain_setup_description(),
+			st::boxLabel),
+		QMargins(padding.left(), 0, padding.right(), padding.bottom()));
+
+	const auto link = box->addRow(
+		object_ptr<Ui::LinkButton>(
+			box,
+			tr::lng_telebrain_setup_get_key(tr::now)),
+		QMargins(padding.left(), 0, padding.right(), padding.bottom()));
+	link->setClickedCallback([] {
+		File::OpenUrl(u"https://openrouter.ai/settings/keys"_q);
+	});
+
+	const auto apiKeyField = box->addRow(
+		object_ptr<Ui::InputField>(
+			box,
+			st::defaultInputField,
+			tr::lng_telebrain_setup_api_key_placeholder()),
+		QMargins(padding.left(), 0, padding.right(), 0));
+
+	const auto weak = base::make_weak(box);
+	box->addButton(tr::lng_telebrain_setup_save(), [=] {
+		const auto key = apiKeyField->getLastText().trimmed();
+		if (!key.isEmpty()) {
+			Core::App().settings().setAiChatApiKey(key);
+			Core::App().saveSettingsDelayed();
+		}
+		if (weak) {
+			weak->closeBox();
+		}
+	});
+	box->addButton(tr::lng_telebrain_setup_skip(), [=] {
+		if (weak) {
+			weak->closeBox();
+		}
+	});
+}

--- a/Telegram/SourceFiles/boxes/telebrain_setup_box.h
+++ b/Telegram/SourceFiles/boxes/telebrain_setup_box.h
@@ -1,0 +1,11 @@
+/*
+This file is part of Telebrain, a fork of Telegram Desktop with AI Copilot.
+
+For license and copyright information please follow this link:
+https://github.com/fedorn/telebrain/blob/dev/LEGAL
+*/
+#pragma once
+
+#include "ui/layers/generic_box.h"
+
+void TelebrainSetupBox(not_null<Ui::GenericBox*> box);

--- a/Telegram/SourceFiles/window/window_controller.cpp
+++ b/Telegram/SourceFiles/window/window_controller.cpp
@@ -31,6 +31,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "data/components/promo_suggestions.h"
 #include "data/data_thread.h"
 #include "settings/settings_common.h"
+#include "boxes/telebrain_setup_box.h"
+#include "core/core_settings.h"
 #include "apiwrap.h" // ApiWrap::acceptTerms.
 #include "styles/style_layers.h"
 
@@ -187,6 +189,14 @@ void Controller::showAccount(
 		if (session) {
 			setupSideBar();
 			setupMain(singlePeerShowAtMsgId, std::move(oldContentCache));
+
+			// Show Telebrain setup dialog when AI settings are unconfigured.
+			const auto &ai = Core::App().settings();
+			if (ai.aiChatApiKey().isEmpty()
+				&& ai.aiChatBaseUrl().isEmpty()
+				&& ai.aiChatModel().isEmpty()) {
+				show(Box(TelebrainSetupBox));
+			}
 
 			session->updates().isIdleValue(
 			) | rpl::filter([=](bool idle) {


### PR DESCRIPTION
## Summary

- Adds a post-login Telebrain setup dialog that guides new users through getting an OpenRouter API key
- Dialog appears after session creation when all three AI settings (API key, base URL, model) are empty
- Includes a clickable "Get API key from OpenRouter" link, a paste-ready input field, and Save & Skip buttons

## Details

New files:
- `boxes/telebrain_setup_box.h` / `.cpp` — GenericBox dialog implementation
- 6 new lang strings (`lng_telebrain_setup_*`)

Modified files:
- `window/window_controller.cpp` — hook after `setupMain()` to show the dialog when AI settings are unconfigured
- `CMakeLists.txt` — register new source files

This implementation uses a GenericBox dialog (modal popup) instead of a window section/layer approach as in https://github.com/fedorn/telebrain/pull/21 (implemented with Cursor/GPT 5.2). The box approach is lighter — a single function vs a full widget class — while achieving the same UX goal.

Written with Claude Opus 4.6 via Claude Code.

## Testing plan

- [x] Fresh login → dialog appears after entering the app
- [x] Click Skip → dialog closes, no key saved, app works normally
- [x] Quit and re-open app → Enter API key → Save → verify key persists in Telebrain settings
- [ ] <s>Re-login with key already set → dialog does NOT appear</s> - currently can't test because of bug https://github.com/fedorn/telebrain/issues/24
- [x] Set only base URL (LM Studio case, no API key) → dialog does NOT appear

## Testing results

Works as expected, screenshot of welcome box:

<img width="864" height="624" alt="image" src="https://github.com/user-attachments/assets/e4afc784-ca4c-4009-a564-6d630d3ca997" />

